### PR TITLE
Declare dependencies for hardware driver and bringup package

### DIFF
--- a/ar3_bringup/package.xml
+++ b/ar3_bringup/package.xml
@@ -13,8 +13,11 @@
   <depend>rviz2</depend>
   <depend>ar3_description</depend>
   <depend>robot_state_publisher</depend>
+  <depend>joint_state_publisher_gui</depend>
   <depend>joint_state_broadcaster</depend>
   <depend>joint_trajectory_controller</depend>
+  <depend>controller_manager</depend>
+
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/ar3_hardware_driver/package.xml
+++ b/ar3_hardware_driver/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
+  <depend>libboost-dev</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
When using rosdep to install all the dependencies for ar3_ros libboost-dev seemed to be missing from the hardware driver package.

You should be able to reproduce the error by building this Dockerfile based on osrf's ros image:
```Dockerfile
FROM docker.io/ros:humble

WORKDIR /opt/ros/example

RUN mkdir src && \
    git clone https://github.com/RIF-Robotics/ar3_ros.git src/ar3_ros

RUN apt-get update && \
    rosdep install -iy --from-paths src && \
    rm -rf /var/lib/apt/lists/ 

RUN . /opt/ros/humble/setup.sh && \
    colcon build
```
